### PR TITLE
ogImage 받아오는 방식 수정

### DIFF
--- a/random-article/src/components/list/list.container.tsx
+++ b/random-article/src/components/list/list.container.tsx
@@ -83,7 +83,7 @@ export default function List() {
         link: input,
         isRead: false,
         description: result.ogDescription || null,
-        image: result.ogImage[0].url,
+        image: result.url || null,
         timestamp: new Date(),
       });
       await updateDoc(doc(db, 'list', listRef.id), { id: listRef.id });


### PR DESCRIPTION
- 배포 위해 openGraphScraper 다운그레이드에 맞춰 ogImage 받아오는 방식 수정